### PR TITLE
Fix typo in container registry domain

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,7 +34,7 @@ jobs:
       run: |-
         LOADED_IMAGE="${GITHUB_REPOSITORY#*/}:latest"
         IMAGE_NAME="ghcr.io/$GITHUB_REPOSITORY:${GITHUB_SHA}"
-        IMAGE_NAME_LATEST="ghrc.io/$GITHUB_REPOSITORY:latest"
+        IMAGE_NAME_LATEST="ghcr.io/$GITHUB_REPOSITORY:latest"
         docker tag "$LOADED_IMAGE" "$IMAGE_NAME"
         docker tag "$LOADED_IMAGE" "$IMAGE_NAME_LATEST"
         docker push "$IMAGE_NAME"

--- a/ci/workflows.cue
+++ b/ci/workflows.cue
@@ -169,7 +169,7 @@ _#publishImage: _#step & {
 	run: """
 		LOADED_IMAGE="${GITHUB_REPOSITORY#*/}:latest"
 		IMAGE_NAME="ghcr.io/$GITHUB_REPOSITORY:${GITHUB_SHA}"
-		IMAGE_NAME_LATEST="ghrc.io/$GITHUB_REPOSITORY:latest"
+		IMAGE_NAME_LATEST="ghcr.io/$GITHUB_REPOSITORY:latest"
 		docker tag "$LOADED_IMAGE" "$IMAGE_NAME"
 		docker tag "$LOADED_IMAGE" "$IMAGE_NAME_LATEST"
 		docker push "$IMAGE_NAME"


### PR DESCRIPTION
Hi `jfroche/advent2021`!

This is not an automatic, 🤖-generated PR, as you can check in my [GitHub profile](https://github.com/p-), I work for GitHub and I am part of the [GitHub Security Lab](https://securitylab.github.com/).

While performing a code search for container registry domains we noticed that this repo contains a misspelled domain name.

If a malicious actor were in control of that misspelled domain, they could potentially perform an attack on the software supply chain of this project and/or steal the credentials used to connect to the container registry (depending on how the misspelled domain name of the container registry is used).
Please fix this typo and check your documentation for similar typos.